### PR TITLE
feat: improve settings file parsing

### DIFF
--- a/models.py
+++ b/models.py
@@ -21,3 +21,14 @@ class TableData(BaseModel):
     table_name: str
     table_columns: list[TableColumn]
     foreign_keys: list[ForeignKeyData]
+
+
+class ColumnChangeSettings(BaseModel):
+    name: str
+    subtype: str | None
+    regex: str | None
+
+
+class TableChangeSettings(BaseModel):
+    table_name: str
+    columns_to_change: list[ColumnChangeSettings]


### PR DESCRIPTION
PR para definir melhor o formato do arquivo JSON de configurações, bem como o parsing feito sobre ele, e a aplicação de funcionalidades da configuração. Agora, podemos especificar detalhes sobre que tipo de valores queremos na coluna de acordo com um subtipo (por enquanto, só implementa UUID), e regex. Para gerar valores aleatórios baseados em regex (simples), foi utilizada a bilioteca externa `rstr` (https://pypi.org/project/rstr/). 